### PR TITLE
Fix wrong example in readme for Phoenix Controller redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ a helper like this
 
 ```elixir
 def redirect_back(conn, opts \\ []) do
-  Phoenix.Controller.redirect to: NavigationHistory.last_path(conn, opts)
+  Phoenix.Controller.redirect(conn, to: NavigationHistory.last_path(conn, opts))
 end
 
 # you can then write


### PR DESCRIPTION
The Phoenix Controller redirect function takes 2 arguments.

https://hexdocs.pm/phoenix/Phoenix.Controller.html#redirect/2