### PR TITLE
README Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add `navigation_history` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:navigation_history, "~> 0.1.0"}]
+  [{:navigation_history, "~> 0.0"}]
 end
 ```
 


### PR DESCRIPTION
You get an old version of `navigation_history` if you follow the README installation instructions.

This change will get the newest version while you are still at `0.X`.