### PR TITLE
Add possibility to pass the session to last_path/3 and last_paths/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ NavigationHistory.last_path(conn) # will return the last navigated path or nil
 NavigationHistory.last_path(conn, 1) # will return the second last navigated path
 NavigationHistory.last_path(conn, default: "/") # will return the last path or "/"
 NavigationHistory.last_paths(conn) # will return a list of the last navigated paths
+NavigationHistory.last_path(session) # instead of passing a conn, can also pass a session
 ```
 
 For example, to redirect the user to the last navigated path in Phoenix, you can use

--- a/lib/navigation_history.ex
+++ b/lib/navigation_history.ex
@@ -12,12 +12,15 @@ defmodule NavigationHistory do
       NavigationHistory.last_path(conn, 1) # returns the second last path visited
       NavigationHistory.last_path(conn, default: "/")  # returns the last path and default to "/" if none available
       NavigationHistory.last_path(conn, key: "admin") # returns the last path tracked by tracker with key "admin"
+      NavigationHistory.last_path(session) # instead of passing a conn, can also pass a session
   """
-  def last_path(conn, index \\ 0, opts \\ [])
-  def last_path(conn, index, _opts) when is_list(index),
-    do: last_path(conn, 0, index)
-  def last_path(conn, index, opts),
-    do: Enum.at(last_paths(conn, opts), index) || opts[:default]
+  def last_path(conn_or_session, index \\ 0, opts \\ [])
+
+  def last_path(conn_or_session, index, _opts) when is_list(index),
+    do: last_path(conn_or_session, 0, index)
+
+  def last_path(conn_or_session, index, opts),
+    do: conn_or_session |> last_paths(opts) |> Enum.at(index) || opts[:default]
 
   @doc """
   Retrieves a list of last tracked paths.
@@ -25,9 +28,10 @@ defmodule NavigationHistory do
   ## Examples:
 
       NavigationHistory.last_paths(conn)
+      NavigationHistory.last_paths(session)
       NavigationHistory.last_paths(conn, key: "admin")
   """
   # NOTE: use defdelegate with optional args when shipped in 1.3
-  def last_paths(conn, opts \\ []),
-    do: NavigationHistory.Session.fetch_paths(conn, opts)
+  def last_paths(conn_or_session, opts \\ []),
+    do: NavigationHistory.Session.fetch_paths(conn_or_session, opts)
 end

--- a/lib/navigation_history/helpers.ex
+++ b/lib/navigation_history/helpers.ex
@@ -6,10 +6,18 @@ defmodule NavigationHistory.Session do
   @default_key "default"
   @paths_delimiter "|"
 
-  def fetch_paths(conn, opts \\ []) do
-    if paths = get_session(conn, key(opts)),
-      do: String.split(paths, @paths_delimiter),
-      else: []
+  def fetch_paths(conn_or_session, opts \\ [])
+
+  def fetch_paths(%Plug.Conn{} = conn, opts) do
+    conn
+    |> get_session(key(opts))
+    |> paths_list()
+  end
+
+  def fetch_paths(%{} = session, opts) do
+    session
+    |> Map.get(key(opts), nil)
+    |> paths_list()
   end
 
   def save_paths(conn, paths, opts),
@@ -17,4 +25,7 @@ defmodule NavigationHistory.Session do
 
   def key(opts),
     do: "#{@session_key_prefix}#{opts[:key] || @default_key}"
+
+  defp paths_list(nil), do: []
+  defp paths_list(path), do: String.split(path, @paths_delimiter)
 end


### PR DESCRIPTION
Would like to propose the following change to the last_path(s) helpers.

Instead of just the conn, let these helpers also accept a map
representing the session. This because when in using Phoenix LiveViews
there is no conn available, but there is the session on mount. This
can be helpful whenever one would like to redirect to the last
non-LiveView path visited.